### PR TITLE
Add support for displaying project prefix

### DIFF
--- a/relative-buffers.el
+++ b/relative-buffers.el
@@ -46,6 +46,11 @@
   :group 'relative-buffers
   :type '(repeat string))
 
+(defcustom relative-buffers-project-prefix nil
+  "Display project prefix in front of buffer name."
+  :group 'relative-buffers
+  :type 'boolean)
+
 ;;;###autoload
 (define-minor-mode relative-buffers-mode
   "Name your buffer relatively to project.
@@ -91,18 +96,20 @@ FILE must be absolute python module file name."
 (defun relative-buffers-directory (directory)
   "Directory relative to project root.
 DIRECTORY must be specified as absolute path."
-  (let ((root (relative-buffers-project-root directory))
-        (directory-path (f-full directory)))
+  (let* ((root (relative-buffers-project-root directory))
+         (directory-path (f-full directory))
+         (prefix (when relative-buffers-project-prefix (concat (file-name-nondirectory (directory-file-name (relative-buffers-project-root directory-path))) "/"))))
     (when (and root (f-ancestor-of? root directory-path))
-      (s-chop-prefix root directory-path))))
+      (concat prefix (s-chop-prefix root directory-path)))))
 
 (defun relative-buffers-file-name (file)
   "File name relative to project root.
 FILE must be specified as absolute path."
   (when file
-    (let ((file-path (f-full file)))
+    (let* ((file-path (f-full file))
+           (prefix (when relative-buffers-project-prefix (concat (file-name-nondirectory (directory-file-name (relative-buffers-project-root file-path))) "/"))))
       (--when-let (relative-buffers-project-root file-path)
-        (s-chop-prefix it file-path)))))
+        (concat prefix (s-chop-prefix it file-path))))))
 
 (defun relative-buffers-project-root (path)
   "Return project root for PATH in different VCS."

--- a/test/relative-buffers-test.el
+++ b/test/relative-buffers-test.el
@@ -71,20 +71,21 @@
 
 ;; Global mode.
 
-(ert-deftest test-open-differnt-files-with-same-name ()
+(ert-deftest test-open-different-files-with-same-name ()
   "Check if renaming work correctly for complex layout.
 - each file has same name
 - each file has same relative path
 - each file placed in different project
 README files on top of any vcs project root may cause this error."
-  (unwind-protect
-      (progn
-        (global-relative-buffers-mode +1)
-        (find-file (f-join test-directory "fixtures/same-name/a/README.rst"))
-        (find-file (f-join test-directory "fixtures/same-name/b/README.rst"))
-        (should (get-buffer "README.rst<2>")))
-    (ignore-errors
-      (global-relative-buffers-mode -1))))
+  (let ((uniquify-buffer-name-style nil))
+    (unwind-protect
+        (progn
+          (global-relative-buffers-mode +1)
+          (find-file (f-join test-directory "fixtures/same-name/a/README.rst"))
+          (find-file (f-join test-directory "fixtures/same-name/b/README.rst"))
+          (should (get-buffer "README.rst<2>")))
+      (ignore-errors
+        (global-relative-buffers-mode -1)))))
 
 (provide 'relative-buffers-test)
 

--- a/test/relative-buffers-test.el
+++ b/test/relative-buffers-test.el
@@ -44,6 +44,12 @@
   (let ((path (f-join (f-root) "tmp")))
     (should (null (relative-buffers-directory path)))))
 
+(ert-deftest test-dired-vc-with-project-prefix ()
+  (let ((relative-buffers-project-prefix t)
+        (path (f-join test-directory "fixtures/vc/subdir/dir")))
+    (should (s-equals? (relative-buffers-directory path)
+                       "vc/subdir/dir/"))))
+
 ;; File.
 
 (ert-deftest test-file-name-vc ()
@@ -57,6 +63,12 @@
 
 (ert-deftest test-file-name-without-file ()
   (should (null (relative-buffers-file-name nil))))
+
+(ert-deftest test-file-name-vc-with-project-prefix ()
+  (let ((relative-buffers-project-prefix t)
+        (path (f-join test-directory "fixtures/vc/subdir/dir/test")))
+    (should (s-equals? (relative-buffers-file-name path)
+                       "vc/subdir/dir/test"))))
 
 ;; Project root.
 


### PR DESCRIPTION
This adds the boolean variable `relative-buffers-project-prefix`, which will default to nil for the previous behavior, but you can now set it to `t` in order to get the project name included in the relative path.

I am frequently working across different projects in the same Emacs instance, and find it easier to always the the project prefix before there is a conflict of files.

I also noticed that the tests failed for me on the latest version 27 of Emacs and I suspect that the default behavior of conflicting buffer name resolving has changed. By default I get the name of the directory appended to the buffer name instead of the <1>, <2>. By setting the variable `uniquify-buffer-name-style` to `nil` during the test I get the expected behavior.