### PR TITLE
Fix project relative buffers when outside of project

### DIFF
--- a/relative-buffers.el
+++ b/relative-buffers.el
@@ -98,18 +98,23 @@ FILE must be absolute python module file name."
 DIRECTORY must be specified as absolute path."
   (let* ((root (relative-buffers-project-root directory))
          (directory-path (f-full directory))
-         (prefix (when relative-buffers-project-prefix (concat (file-name-nondirectory (directory-file-name (relative-buffers-project-root directory-path))) "/"))))
-    (when (and root (f-ancestor-of? root directory-path))
-      (concat prefix (s-chop-prefix root directory-path)))))
+         (prefix (if (and relative-buffers-project-prefix root)
+                     (file-name-directory (directory-file-name root))
+                   root)))
+    (when (and prefix (f-ancestor-of? root directory-path))
+      (s-chop-prefix prefix directory-path))))
 
 (defun relative-buffers-file-name (file)
   "File name relative to project root.
 FILE must be specified as absolute path."
   (when file
-    (let* ((file-path (f-full file))
-           (prefix (when relative-buffers-project-prefix (concat (file-name-nondirectory (directory-file-name (relative-buffers-project-root file-path))) "/"))))
-      (--when-let (relative-buffers-project-root file-path)
-        (concat prefix (s-chop-prefix it file-path))))))
+    (let* ((root (relative-buffers-project-root file))
+           (file-path (f-full file))
+           (prefix (if (and relative-buffers-project-prefix root)
+                       (file-name-directory (directory-file-name root))
+                     root)))
+      (when prefix
+        (s-chop-prefix prefix file-path)))))
 
 (defun relative-buffers-project-root (path)
   "Return project root for PATH in different VCS."

--- a/test/relative-buffers-test.el
+++ b/test/relative-buffers-test.el
@@ -31,40 +31,56 @@
 ;; Dired.
 
 (ert-deftest test-dired-vc ()
-  (let ((path (f-join test-directory "fixtures/vc/subdir/dir")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join test-directory "fixtures/vc/subdir/dir")))
     (should (s-equals? (relative-buffers-directory path)
                        "subdir/dir/"))))
 
 (ert-deftest test-dired-vc-topdir ()
-  (let ((path (f-join test-directory "fixtures/vc/subdir")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join test-directory "fixtures/vc/subdir")))
     (should (s-equals? (relative-buffers-directory path)
                        "subdir/"))))
 
 (ert-deftest test-dired-simple-directory ()
-  (let ((path (f-join (f-root) "tmp")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join (f-root) "tmp")))
     (should (null (relative-buffers-directory path)))))
 
-(ert-deftest test-dired-vc-with-project-prefix ()
+(ert-deftest test-project-prefix-dired-vc ()
   (let ((relative-buffers-project-prefix t)
         (path (f-join test-directory "fixtures/vc/subdir/dir")))
     (should (s-equals? (relative-buffers-directory path)
                        "vc/subdir/dir/"))))
 
+(ert-deftest test-project-prefix-dired-simple-directory ()
+  (let ((relative-buffers-project-prefix t)
+        (path (f-join (f-root) "tmp")))
+    (should (null (relative-buffers-directory path)))))
+
 ;; File.
 
 (ert-deftest test-file-name-vc ()
-  (let ((path (f-join test-directory "fixtures/vc/subdir/dir/test")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join test-directory "fixtures/vc/subdir/dir/test")))
     (should (s-equals? (relative-buffers-file-name path)
                        "subdir/dir/test"))))
 
 (ert-deftest test-file-name-simple-file ()
-  (let ((path (f-join (f-root) "tmp" "simple")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join (f-root) "tmp" "simple")))
     (should (null (relative-buffers-file-name path)))))
 
 (ert-deftest test-file-name-without-file ()
-  (should (null (relative-buffers-file-name nil))))
+  (let ((relative-buffers-project-prefix nil))
+    (should (null (relative-buffers-file-name nil)))))
 
-(ert-deftest test-file-name-vc-with-project-prefix ()
+(ert-deftest test-project-prefix-file-name-simple-file ()
+  (let ((relative-buffers-project-prefix t)
+        (path (f-join (f-root) "tmp" "simple")))
+    (should (null (relative-buffers-file-name path)))))
+
+(ert-deftest test-project-prefix-file-name-vc ()
   (let ((relative-buffers-project-prefix t)
         (path (f-join test-directory "fixtures/vc/subdir/dir/test")))
     (should (s-equals? (relative-buffers-file-name path)
@@ -73,12 +89,14 @@
 ;; Project root.
 
 (ert-deftest test-project-root ()
-  (let ((path (f-join test-directory "fixtures/vc/subdir/dir/test")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join test-directory "fixtures/vc/subdir/dir/test")))
     (should (s-equals? (relative-buffers-project-root path)
                        (f-slash (f-join test-directory "fixtures" "vc"))))))
 
 (ert-deftest test-not-project-root ()
-  (let ((path (f-join (f-root) "tmp")))
+  (let ((relative-buffers-project-prefix nil)
+        (path (f-join (f-root) "tmp")))
     (should (null (relative-buffers-project-root path)))))
 
 ;; Global mode.
@@ -89,7 +107,8 @@
 - each file has same relative path
 - each file placed in different project
 README files on top of any vcs project root may cause this error."
-  (let ((uniquify-buffer-name-style nil))
+  (let ((relative-buffers-project-prefix nil)
+        (uniquify-buffer-name-style nil))
     (unwind-protect
         (progn
           (global-relative-buffers-mode +1)


### PR DESCRIPTION
So I realized I messed up earlier and my change triggered a `(wrong-type-argument stringp nil)` when `relative-buffers-project-prefix` is enabled and you are visiting a buffer that is not inside a project.

I added the missing tests for those cases to ensure this won't happen again. After writing the tests and fixing the issue I realized the code started to be a bit complicated and that the original code already chop prefix, so I decided to change the part that is chopped instead of chopping the project root and then adding it back as a prefix.

Hope this looks better and sorry for the contribution of broken code, I hope no-one ran into this issue.